### PR TITLE
Add Mod Downloads Count

### DIFF
--- a/docs/classes/_customerrors_.httperror.md
+++ b/docs/classes/_customerrors_.httperror.md
@@ -33,7 +33,7 @@ Error thrown if an HTTP error is reported (HTTP code 4xx or 5xx)
 
 \+ **new HTTPError**(`statusCode`: number, `message`: string, `body`: string): *[HTTPError](_customerrors_.httperror.md)*
 
-*Defined in [src/customErrors.ts:36](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L36)*
+*Defined in [src/customErrors.ts:36](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L36)*
 
 **Parameters:**
 
@@ -91,6 +91,6 @@ Defined in node_modules/typescript/lib/lib.es5.d.ts:984
 
 • **get body**(): *string*
 
-*Defined in [src/customErrors.ts:42](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L42)*
+*Defined in [src/customErrors.ts:42](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L42)*
 
 **Returns:** *string*

--- a/docs/classes/_customerrors_.jwtexpirederror.md
+++ b/docs/classes/_customerrors_.jwtexpirederror.md
@@ -30,7 +30,7 @@ You should not see this error in your application as a refresh is performed when
 
 \+ **new JwtExpiredError**(): *[JwtExpiredError](_customerrors_.jwtexpirederror.md)*
 
-*Defined in [src/customErrors.ts:82](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L82)*
+*Defined in [src/customErrors.ts:82](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L82)*
 
 **Returns:** *[JwtExpiredError](_customerrors_.jwtexpirederror.md)*
 

--- a/docs/classes/_customerrors_.nexuserror.md
+++ b/docs/classes/_customerrors_.nexuserror.md
@@ -34,7 +34,7 @@ Error reported by the nexus api
 
 \+ **new NexusError**(`message`: string, `statusCode`: number, `url`: string): *[NexusError](_customerrors_.nexuserror.md)*
 
-*Defined in [src/customErrors.ts:52](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L52)*
+*Defined in [src/customErrors.ts:52](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L52)*
 
 **Parameters:**
 
@@ -92,7 +92,7 @@ Defined in node_modules/typescript/lib/lib.es5.d.ts:984
 
 • **get request**(): *string*
 
-*Defined in [src/customErrors.ts:63](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L63)*
+*Defined in [src/customErrors.ts:63](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L63)*
 
 **Returns:** *string*
 
@@ -102,6 +102,6 @@ ___
 
 • **get statusCode**(): *number*
 
-*Defined in [src/customErrors.ts:59](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L59)*
+*Defined in [src/customErrors.ts:59](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L59)*
 
 **Returns:** *number*

--- a/docs/classes/_customerrors_.parameterinvalid.md
+++ b/docs/classes/_customerrors_.parameterinvalid.md
@@ -29,7 +29,7 @@ API called with an invalid parameter
 
 \+ **new ParameterInvalid**(`message`: any): *[ParameterInvalid](_customerrors_.parameterinvalid.md)*
 
-*Defined in [src/customErrors.ts:71](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L71)*
+*Defined in [src/customErrors.ts:71](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L71)*
 
 **Parameters:**
 

--- a/docs/classes/_customerrors_.protocolerror.md
+++ b/docs/classes/_customerrors_.protocolerror.md
@@ -29,7 +29,7 @@ Error thrown when a protocol error is reported.
 
 \+ **new ProtocolError**(`message`: string): *[ProtocolError](_customerrors_.protocolerror.md)*
 
-*Defined in [src/customErrors.ts:14](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L14)*
+*Defined in [src/customErrors.ts:14](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L14)*
 
 **Parameters:**
 

--- a/docs/classes/_customerrors_.ratelimiterror.md
+++ b/docs/classes/_customerrors_.ratelimiterror.md
@@ -30,7 +30,7 @@ You should not see this error in your application as it is handled internally
 
 \+ **new RateLimitError**(): *[RateLimitError](_customerrors_.ratelimiterror.md)*
 
-*Defined in [src/customErrors.ts:25](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L25)*
+*Defined in [src/customErrors.ts:25](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L25)*
 
 **Returns:** *[RateLimitError](_customerrors_.ratelimiterror.md)*
 

--- a/docs/classes/_customerrors_.timeouterror.md
+++ b/docs/classes/_customerrors_.timeouterror.md
@@ -29,7 +29,7 @@ Error thrown if a request timed out
 
 \+ **new TimeoutError**(`message`: any): *[TimeoutError](_customerrors_.timeouterror.md)*
 
-*Defined in [src/customErrors.ts:4](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/customErrors.ts#L4)*
+*Defined in [src/customErrors.ts:4](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/customErrors.ts#L4)*
 
 **Parameters:**
 

--- a/docs/classes/_nexus_.nexus.md
+++ b/docs/classes/_nexus_.nexus.md
@@ -55,7 +55,7 @@ Main class of the api
 
 \+ **new Nexus**(`appName`: string, `appVersion`: string, `defaultGame`: string, `timeout?`: number): *[Nexus](_nexus_.nexus.md)*
 
-*Defined in [src/Nexus.ts:200](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L200)*
+*Defined in [src/Nexus.ts:200](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L200)*
 
 Constructor
 please don't use this directly, use Nexus.create
@@ -77,7 +77,7 @@ Name | Type | Description |
 
 • **events**: *TypedEmitter‹[INexusEvents](../interfaces/_types_.inexusevents.md)›* = new EventEmitter() as TypedEmitter<types.INexusEvents>
 
-*Defined in [src/Nexus.ts:191](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L191)*
+*Defined in [src/Nexus.ts:191](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L191)*
 
 ## Methods
 
@@ -85,7 +85,7 @@ Name | Type | Description |
 
 ▸ **endorseMod**(`modId`: number, `modVersion`: string, `endorseStatus`: "endorse" | "abstain", `gameId?`: string): *Promise‹[IEndorseResponse](../interfaces/_types_.iendorseresponse.md)›*
 
-*Defined in [src/Nexus.ts:471](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L471)*
+*Defined in [src/Nexus.ts:471](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L471)*
 
 Endorse/Unendorse a mod
 
@@ -106,7 +106,7 @@ ___
 
 ▸ **getChangelogs**(`modId`: number, `gameId?`: string): *Promise‹[IChangelogs](../interfaces/_types_.ichangelogs.md)›*
 
-*Defined in [src/Nexus.ts:500](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L500)*
+*Defined in [src/Nexus.ts:500](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L500)*
 
 retrieve all changelogs for a mod
 
@@ -125,7 +125,7 @@ ___
 
 ▸ **getColorschemes**(): *Promise‹[IColourScheme](../interfaces/_types_.icolourscheme.md)[]›*
 
-*Defined in [src/Nexus.ts:428](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L428)*
+*Defined in [src/Nexus.ts:428](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L428)*
 
 get list of colorschemes
 
@@ -137,7 +137,7 @@ ___
 
 ▸ **getColourschemes**(): *Promise‹[IColourScheme](../interfaces/_types_.icolourscheme.md)[]›*
 
-*Defined in [src/Nexus.ts:420](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L420)*
+*Defined in [src/Nexus.ts:420](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L420)*
 
 get list of colourschemes
 
@@ -149,7 +149,7 @@ ___
 
 ▸ **getDownloadURLs**(`modId`: number, `fileId`: number, `key?`: string, `expires?`: number, `gameId?`: string): *Promise‹[IDownloadURL](../interfaces/_types_.idownloadurl.md)[]›*
 
-*Defined in [src/Nexus.ts:547](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L547)*
+*Defined in [src/Nexus.ts:547](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L547)*
 
 generate download links for a file
 If the user isn't premium on Nexus Mods, this requires a key that can only
@@ -173,7 +173,7 @@ ___
 
 ▸ **getEndorsements**(): *Promise‹[IEndorsement](../interfaces/_types_.iendorsement.md)[]›*
 
-*Defined in [src/Nexus.ts:412](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L412)*
+*Defined in [src/Nexus.ts:412](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L412)*
 
 get list of endorsements the user has given
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **getFileByMD5**(`hash`: string, `gameId?`: string): *Promise‹[IMD5Result](../interfaces/_types_.imd5result.md)[]›*
 
-*Defined in [src/Nexus.ts:572](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L572)*
+*Defined in [src/Nexus.ts:572](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L572)*
 
 find information about a file based on its md5 hash
 This can be used to find info about a file when you don't have its modid and fileid
@@ -210,7 +210,7 @@ ___
 
 ▸ **getFileInfo**(`modId`: number, `fileId`: number, `gameId?`: string): *Promise‹[IFileInfo](../interfaces/_types_.ifileinfo.md)›*
 
-*Defined in [src/Nexus.ts:528](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L528)*
+*Defined in [src/Nexus.ts:528](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L528)*
 
 get details about a file
 
@@ -230,7 +230,7 @@ ___
 
 ▸ **getGameInfo**(`gameId?`: string): *Promise‹[IGameInfo](../interfaces/_types_.igameinfo.md)›*
 
-*Defined in [src/Nexus.ts:440](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L440)*
+*Defined in [src/Nexus.ts:440](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L440)*
 
 retrieve details about a specific game
 
@@ -248,7 +248,7 @@ ___
 
 ▸ **getGames**(): *Promise‹[IGameListEntry](../interfaces/_types_.igamelistentry.md)[]›*
 
-*Defined in [src/Nexus.ts:371](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L371)*
+*Defined in [src/Nexus.ts:371](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L371)*
 
 retrieve a list of all games currently supported by Nexus Mods
 
@@ -262,7 +262,7 @@ ___
 
 ▸ **getLatestAdded**(`gameId?`: string): *Promise‹[IModInfo](../interfaces/_types_.imodinfo.md)[]›*
 
-*Defined in [src/Nexus.ts:380](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L380)*
+*Defined in [src/Nexus.ts:380](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L380)*
 
 get list of the latest added mods
 
@@ -280,7 +280,7 @@ ___
 
 ▸ **getLatestUpdated**(`gameId?`: string): *Promise‹[IModInfo](../interfaces/_types_.imodinfo.md)[]›*
 
-*Defined in [src/Nexus.ts:391](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L391)*
+*Defined in [src/Nexus.ts:391](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L391)*
 
 get list of the latest updated mods
 
@@ -298,7 +298,7 @@ ___
 
 ▸ **getModFiles**(`modId`: number, `gameId?`: string): *Promise‹[IModFiles](../interfaces/_types_.imodfiles.md)›*
 
-*Defined in [src/Nexus.ts:512](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L512)*
+*Defined in [src/Nexus.ts:512](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L512)*
 
 get list of all files uploaded for a mod
 
@@ -317,7 +317,7 @@ ___
 
 ▸ **getModInfo**(`modId`: number, `gameId?`: string): *Promise‹[IModInfo](../interfaces/_types_.imodinfo.md)›*
 
-*Defined in [src/Nexus.ts:488](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L488)*
+*Defined in [src/Nexus.ts:488](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L488)*
 
 retrieve details about a mod
 
@@ -336,7 +336,7 @@ ___
 
 ▸ **getOwnIssues**(): *Promise‹[IIssue](../interfaces/_types_.iissue.md)[]›*
 
-*Defined in [src/Nexus.ts:598](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L598)*
+*Defined in [src/Nexus.ts:598](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L598)*
 
 get list of issues reported by this user
 FOR INTERNAL USE ONLY
@@ -349,7 +349,7 @@ ___
 
 ▸ **getRateLimits**(): *object*
 
-*Defined in [src/Nexus.ts:300](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L300)*
+*Defined in [src/Nexus.ts:300](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L300)*
 
 **Returns:** *object*
 
@@ -363,7 +363,7 @@ ___
 
 ▸ **getRecentlyUpdatedMods**(`period`: types.UpdatePeriod, `gameId?`: string): *Promise‹[IUpdateEntry](../interfaces/_types_.iupdateentry.md)[]›*
 
-*Defined in [src/Nexus.ts:453](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L453)*
+*Defined in [src/Nexus.ts:453](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L453)*
 
 retrieve list of mods for a game that has recently been updated
 
@@ -382,7 +382,7 @@ ___
 
 ▸ **getTrackedMods**(): *Promise‹[ITrackedMod](../interfaces/_types_.itrackedmod.md)[]›*
 
-*Defined in [src/Nexus.ts:323](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L323)*
+*Defined in [src/Nexus.ts:323](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L323)*
 
 Get list of all mods being tracked by the user
 
@@ -394,7 +394,7 @@ ___
 
 ▸ **getTrending**(`gameId?`: string): *Promise‹[IModInfo](../interfaces/_types_.imodinfo.md)[]›*
 
-*Defined in [src/Nexus.ts:402](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L402)*
+*Defined in [src/Nexus.ts:402](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L402)*
 
 get list of trending mods
 
@@ -412,7 +412,7 @@ ___
 
 ▸ **getValidationResult**(): *[IValidateKeyResponse](../interfaces/_types_.ivalidatekeyresponse.md)*
 
-*Defined in [src/Nexus.ts:274](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L274)*
+*Defined in [src/Nexus.ts:274](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L274)*
 
 retrieve the result of the last key validation.
 This is useful primarily after creating the object with Nexus.create
@@ -425,7 +425,7 @@ ___
 
 ▸ **sendFeedback**(`title`: string, `message`: string, `fileBundle`: string, `anonymous`: boolean, `groupingKey?`: string, `id?`: string): *Promise‹[IFeedbackResponse](../interfaces/_types_.ifeedbackresponse.md)›*
 
-*Defined in [src/Nexus.ts:615](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L615)*
+*Defined in [src/Nexus.ts:615](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L615)*
 
 send a feedback message
 FOR INTERNAL USE ONLY
@@ -449,7 +449,7 @@ ___
 
 ▸ **setGame**(`gameId`: string): *void*
 
-*Defined in [src/Nexus.ts:266](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L266)*
+*Defined in [src/Nexus.ts:266](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L266)*
 
 change the default game id
 
@@ -467,7 +467,7 @@ ___
 
 ▸ **setKey**(`apiKey`: string): *Promise‹[IValidateKeyResponse](../interfaces/_types_.ivalidatekeyresponse.md)›*
 
-*Defined in [src/Nexus.ts:283](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L283)*
+*Defined in [src/Nexus.ts:283](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L283)*
 
 change the API Key and validate it This can also be used to unset the key
 
@@ -487,7 +487,7 @@ ___
 
 ▸ **trackMod**(`modId`: string, `gameId?`: string): *Promise‹[ITrackResponse](../interfaces/_types_.itrackresponse.md)›*
 
-*Defined in [src/Nexus.ts:334](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L334)*
+*Defined in [src/Nexus.ts:334](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L334)*
 
 start tracking a mod
 
@@ -506,7 +506,7 @@ ___
 
 ▸ **untrackMod**(`modId`: string, `gameId?`: string): *Promise‹[ITrackResponse](../interfaces/_types_.itrackresponse.md)›*
 
-*Defined in [src/Nexus.ts:353](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L353)*
+*Defined in [src/Nexus.ts:353](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L353)*
 
 stop tracking a mod
 
@@ -525,7 +525,7 @@ ___
 
 ▸ **validateKey**(`key?`: string): *Promise‹[IValidateKeyResponse](../interfaces/_types_.ivalidatekeyresponse.md)›*
 
-*Defined in [src/Nexus.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L314)*
+*Defined in [src/Nexus.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L314)*
 
 validate a specific API key
 This does not update the request quota or the cached validation result so it's
@@ -545,7 +545,7 @@ ___
 
 ▸ **create**(`apiKey`: string, `appName`: string, `appVersion`: string, `defaultGame`: string, `timeout?`: number): *Promise‹[Nexus](_nexus_.nexus.md)›*
 
-*Defined in [src/Nexus.ts:248](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L248)*
+*Defined in [src/Nexus.ts:248](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L248)*
 
 create a Nexus instance and immediately verify the API Key
 
@@ -567,7 +567,7 @@ ___
 
 ▸ **createWithOAuth**(`credentials`: [IOAuthCredentials](../interfaces/_types_.ioauthcredentials.md), `config`: [IOAuthConfig](../interfaces/_types_.ioauthconfig.md), `appName`: string, `appVersion`: string, `defaultGame`: string, `timeout?`: number): *Promise‹[Nexus](_nexus_.nexus.md)›*
 
-*Defined in [src/Nexus.ts:254](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L254)*
+*Defined in [src/Nexus.ts:254](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L254)*
 
 **Parameters:**
 

--- a/docs/classes/_quota_.quota.md
+++ b/docs/classes/_quota_.quota.md
@@ -24,7 +24,7 @@
 
 \+ **new Quota**(`init`: number, `max`: number, `msPerIncrement`: number): *[Quota](_quota_.quota.md)*
 
-*Defined in [src/Quota.ts:17](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Quota.ts#L17)*
+*Defined in [src/Quota.ts:17](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Quota.ts#L17)*
 
 **Parameters:**
 
@@ -42,7 +42,7 @@ Name | Type |
 
 ▸ **block**(): *boolean*
 
-*Defined in [src/Quota.ts:35](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Quota.ts#L35)*
+*Defined in [src/Quota.ts:35](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Quota.ts#L35)*
 
 signal that the request was blocked by the server with an error code that
 indicates client is sending too many requests
@@ -57,7 +57,7 @@ ___
 
 ▸ **updateLimit**(`limit`: number): *void*
 
-*Defined in [src/Quota.ts:25](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Quota.ts#L25)*
+*Defined in [src/Quota.ts:25](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Quota.ts#L25)*
 
 **Parameters:**
 
@@ -73,6 +73,6 @@ ___
 
 ▸ **wait**(): *Promise‹void›*
 
-*Defined in [src/Quota.ts:47](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Quota.ts#L47)*
+*Defined in [src/Quota.ts:47](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Quota.ts#L47)*
 
 **Returns:** *Promise‹void›*

--- a/docs/interfaces/_nexus_.irequestargs.md
+++ b/docs/interfaces/_nexus_.irequestargs.md
@@ -24,7 +24,7 @@
 
 • **cookies**? : *any*
 
-*Defined in [src/Nexus.ts:21](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L21)*
+*Defined in [src/Nexus.ts:21](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L21)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **data**? : *any*
 
-*Defined in [src/Nexus.ts:23](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L23)*
+*Defined in [src/Nexus.ts:23](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L23)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **headers**? : *any*
 
-*Defined in [src/Nexus.ts:20](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L20)*
+*Defined in [src/Nexus.ts:20](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L20)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **method**? : *[REST_METHOD](../modules/_nexus_.md#rest_method)*
 
-*Defined in [src/Nexus.ts:24](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L24)*
+*Defined in [src/Nexus.ts:24](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L24)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **path**? : *any*
 
-*Defined in [src/Nexus.ts:22](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L22)*
+*Defined in [src/Nexus.ts:22](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L22)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **requestConfig**? : *object*
 
-*Defined in [src/Nexus.ts:25](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L25)*
+*Defined in [src/Nexus.ts:25](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L25)*
 
 #### Type declaration:
 
@@ -80,7 +80,7 @@ ___
 
 • **responseConfig**? : *object*
 
-*Defined in [src/Nexus.ts:30](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L30)*
+*Defined in [src/Nexus.ts:30](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L30)*
 
 #### Type declaration:
 

--- a/docs/interfaces/_types_.icategory.md
+++ b/docs/interfaces/_types_.icategory.md
@@ -22,7 +22,7 @@ Nexus Mods category
 
 • **category_id**: *number*
 
-*Defined in [src/types.ts:280](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L280)*
+*Defined in [src/types.ts:288](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L288)*
 
 numerical id
 
@@ -32,7 +32,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:284](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L284)*
+*Defined in [src/types.ts:292](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L292)*
 
 display name
 
@@ -42,7 +42,7 @@ ___
 
 • **parent_category**: *number | false*
 
-*Defined in [src/types.ts:292](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L292)*
+*Defined in [src/types.ts:300](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L300)*
 
 id of the parent category or false if it's a top-level
 category.

--- a/docs/interfaces/_types_.icategory.md
+++ b/docs/interfaces/_types_.icategory.md
@@ -22,7 +22,7 @@ Nexus Mods category
 
 • **category_id**: *number*
 
-*Defined in [src/types.ts:288](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L288)*
+*Defined in [src/types.ts:288](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L288)*
 
 numerical id
 
@@ -32,7 +32,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:292](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L292)*
+*Defined in [src/types.ts:292](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L292)*
 
 display name
 
@@ -42,7 +42,7 @@ ___
 
 • **parent_category**: *number | false*
 
-*Defined in [src/types.ts:300](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L300)*
+*Defined in [src/types.ts:300](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L300)*
 
 id of the parent category or false if it's a top-level
 category.

--- a/docs/interfaces/_types_.icolourscheme.md
+++ b/docs/interfaces/_types_.icolourscheme.md
@@ -24,7 +24,7 @@ colourscheme entry as returned by getColourSchemes
 
 • **darker_colour**: *string*
 
-*Defined in [src/types.ts:481](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L481)*
+*Defined in [src/types.ts:489](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L489)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types.ts:477](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L477)*
+*Defined in [src/types.ts:485](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L485)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:478](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L478)*
+*Defined in [src/types.ts:486](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L486)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **primary_colour**: *string*
 
-*Defined in [src/types.ts:479](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L479)*
+*Defined in [src/types.ts:487](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L487)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • **secondary_colour**: *string*
 
-*Defined in [src/types.ts:480](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L480)*
+*Defined in [src/types.ts:488](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L488)*

--- a/docs/interfaces/_types_.icolourscheme.md
+++ b/docs/interfaces/_types_.icolourscheme.md
@@ -24,7 +24,7 @@ colourscheme entry as returned by getColourSchemes
 
 • **darker_colour**: *string*
 
-*Defined in [src/types.ts:489](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L489)*
+*Defined in [src/types.ts:489](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L489)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types.ts:485](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L485)*
+*Defined in [src/types.ts:485](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L485)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:486](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L486)*
+*Defined in [src/types.ts:486](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L486)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **primary_colour**: *string*
 
-*Defined in [src/types.ts:487](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L487)*
+*Defined in [src/types.ts:487](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L487)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • **secondary_colour**: *string*
 
-*Defined in [src/types.ts:488](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L488)*
+*Defined in [src/types.ts:488](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L488)*

--- a/docs/interfaces/_types_.idownloadurl.md
+++ b/docs/interfaces/_types_.idownloadurl.md
@@ -24,7 +24,7 @@ useful to store it for more than a few minutes
 
 • **URI**: *string*
 
-*Defined in [src/types.ts:361](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L361)*
+*Defined in [src/types.ts:369](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L369)*
 
 the url itself
 
@@ -34,7 +34,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:365](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L365)*
+*Defined in [src/types.ts:373](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L373)*
 
 Display name of the download server hosting the file
 
@@ -44,6 +44,6 @@ ___
 
 • **short_name**: *string*
 
-*Defined in [src/types.ts:369](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L369)*
+*Defined in [src/types.ts:377](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L377)*
 
 short name (id?) of the download server

--- a/docs/interfaces/_types_.idownloadurl.md
+++ b/docs/interfaces/_types_.idownloadurl.md
@@ -24,7 +24,7 @@ useful to store it for more than a few minutes
 
 • **URI**: *string*
 
-*Defined in [src/types.ts:369](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L369)*
+*Defined in [src/types.ts:369](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L369)*
 
 the url itself
 
@@ -34,7 +34,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:373](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L373)*
+*Defined in [src/types.ts:373](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L373)*
 
 Display name of the download server hosting the file
 
@@ -44,6 +44,6 @@ ___
 
 • **short_name**: *string*
 
-*Defined in [src/types.ts:377](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L377)*
+*Defined in [src/types.ts:377](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L377)*
 
 short name (id?) of the download server

--- a/docs/interfaces/_types_.iendorsement.md
+++ b/docs/interfaces/_types_.iendorsement.md
@@ -24,7 +24,7 @@ response to a request for endorsements
 
 • **date**: *number*
 
-*Defined in [src/types.ts:447](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L447)*
+*Defined in [src/types.ts:455](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L455)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **domain_name**: *string*
 
-*Defined in [src/types.ts:446](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L446)*
+*Defined in [src/types.ts:454](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L454)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **mod_id**: *number*
 
-*Defined in [src/types.ts:445](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L445)*
+*Defined in [src/types.ts:453](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L453)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **status**: *[EndorsedStatus](../modules/_types_.md#endorsedstatus)*
 
-*Defined in [src/types.ts:449](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L449)*
+*Defined in [src/types.ts:457](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L457)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • **version**: *string*
 
-*Defined in [src/types.ts:448](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L448)*
+*Defined in [src/types.ts:456](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L456)*

--- a/docs/interfaces/_types_.iendorsement.md
+++ b/docs/interfaces/_types_.iendorsement.md
@@ -24,7 +24,7 @@ response to a request for endorsements
 
 • **date**: *number*
 
-*Defined in [src/types.ts:455](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L455)*
+*Defined in [src/types.ts:455](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L455)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **domain_name**: *string*
 
-*Defined in [src/types.ts:454](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L454)*
+*Defined in [src/types.ts:454](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L454)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **mod_id**: *number*
 
-*Defined in [src/types.ts:453](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L453)*
+*Defined in [src/types.ts:453](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L453)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **status**: *[EndorsedStatus](../modules/_types_.md#endorsedstatus)*
 
-*Defined in [src/types.ts:457](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L457)*
+*Defined in [src/types.ts:457](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L457)*
 
 ___
 
@@ -56,4 +56,4 @@ ___
 
 • **version**: *string*
 
-*Defined in [src/types.ts:456](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L456)*
+*Defined in [src/types.ts:456](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L456)*

--- a/docs/interfaces/_types_.iendorseresponse.md
+++ b/docs/interfaces/_types_.iendorseresponse.md
@@ -21,7 +21,7 @@
 
 • **message**: *string*
 
-*Defined in [src/types.ts:459](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L459)*
+*Defined in [src/types.ts:467](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L467)*
 
 textual reply to the request, something like "Updated to: Endorsed"
 
@@ -31,4 +31,4 @@ ___
 
 • **status**: *[EndorsedStatus](../modules/_types_.md#endorsedstatus)*
 
-*Defined in [src/types.ts:460](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L460)*
+*Defined in [src/types.ts:468](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L468)*

--- a/docs/interfaces/_types_.iendorseresponse.md
+++ b/docs/interfaces/_types_.iendorseresponse.md
@@ -21,7 +21,7 @@
 
 • **message**: *string*
 
-*Defined in [src/types.ts:467](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L467)*
+*Defined in [src/types.ts:467](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L467)*
 
 textual reply to the request, something like "Updated to: Endorsed"
 
@@ -31,4 +31,4 @@ ___
 
 • **status**: *[EndorsedStatus](../modules/_types_.md#endorsedstatus)*
 
-*Defined in [src/types.ts:468](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L468)*
+*Defined in [src/types.ts:468](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L468)*

--- a/docs/interfaces/_types_.ifeedbackresponse.md
+++ b/docs/interfaces/_types_.ifeedbackresponse.md
@@ -29,7 +29,7 @@ INTERNAL USE ONLY
 
 • **count**: *number*
 
-*Defined in [src/types.ts:423](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L423)*
+*Defined in [src/types.ts:431](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L431)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **created_at**: *string*
 
-*Defined in [src/types.ts:417](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L417)*
+*Defined in [src/types.ts:425](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L425)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • **github_issue**: *[IGithubIssue](_types_.igithubissue.md)*
 
-*Defined in [src/types.ts:421](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L421)*
+*Defined in [src/types.ts:429](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L429)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **grouping_key**: *string*
 
-*Defined in [src/types.ts:420](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L420)*
+*Defined in [src/types.ts:428](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L428)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types.ts:415](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L415)*
+*Defined in [src/types.ts:423](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L423)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **reference**: *string*
 
-*Defined in [src/types.ts:419](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L419)*
+*Defined in [src/types.ts:427](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L427)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **status**: *number*
 
-*Defined in [src/types.ts:416](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L416)*
+*Defined in [src/types.ts:424](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L424)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **updated_at**: *string*
 
-*Defined in [src/types.ts:418](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L418)*
+*Defined in [src/types.ts:426](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L426)*
 
 ___
 
@@ -93,4 +93,4 @@ ___
 
 • **user_blacklisted**: *boolean*
 
-*Defined in [src/types.ts:422](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L422)*
+*Defined in [src/types.ts:430](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L430)*

--- a/docs/interfaces/_types_.ifeedbackresponse.md
+++ b/docs/interfaces/_types_.ifeedbackresponse.md
@@ -29,7 +29,7 @@ INTERNAL USE ONLY
 
 • **count**: *number*
 
-*Defined in [src/types.ts:431](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L431)*
+*Defined in [src/types.ts:431](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L431)*
 
 ___
 
@@ -37,7 +37,7 @@ ___
 
 • **created_at**: *string*
 
-*Defined in [src/types.ts:425](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L425)*
+*Defined in [src/types.ts:425](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L425)*
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 • **github_issue**: *[IGithubIssue](_types_.igithubissue.md)*
 
-*Defined in [src/types.ts:429](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L429)*
+*Defined in [src/types.ts:429](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L429)*
 
 ___
 
@@ -53,7 +53,7 @@ ___
 
 • **grouping_key**: *string*
 
-*Defined in [src/types.ts:428](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L428)*
+*Defined in [src/types.ts:428](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L428)*
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types.ts:423](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L423)*
+*Defined in [src/types.ts:423](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L423)*
 
 ___
 
@@ -69,7 +69,7 @@ ___
 
 • **reference**: *string*
 
-*Defined in [src/types.ts:427](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L427)*
+*Defined in [src/types.ts:427](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L427)*
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 • **status**: *number*
 
-*Defined in [src/types.ts:424](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L424)*
+*Defined in [src/types.ts:424](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L424)*
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 • **updated_at**: *string*
 
-*Defined in [src/types.ts:426](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L426)*
+*Defined in [src/types.ts:426](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L426)*
 
 ___
 
@@ -93,4 +93,4 @@ ___
 
 • **user_blacklisted**: *boolean*
 
-*Defined in [src/types.ts:430](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L430)*
+*Defined in [src/types.ts:430](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L430)*

--- a/docs/interfaces/_types_.ifileinfo.md
+++ b/docs/interfaces/_types_.ifileinfo.md
@@ -35,7 +35,7 @@ Information about a specific mod file
 
 • **category_id**: *number*
 
-*Defined in [src/types.ts:165](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L165)*
+*Defined in [src/types.ts:173](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L173)*
 
 File type as a number (1 = main, 2 = patch, 3 = optional, 4 = old, 6 = deleted)
 
@@ -45,7 +45,7 @@ ___
 
 • **category_name**: *string*
 
-*Defined in [src/types.ts:169](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L169)*
+*Defined in [src/types.ts:177](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L177)*
 
 File type as a string ('MAIN', 'PATCH', 'OPTION', 'OLD_VERSION', 'DELETED')
 
@@ -55,7 +55,7 @@ ___
 
 • **changelog_html**: *string*
 
-*Defined in [src/types.ts:174](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L174)*
+*Defined in [src/types.ts:182](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L182)*
 
 html encoded changelog (matched via file version)
 null if there is none
@@ -66,7 +66,7 @@ ___
 
 • **content_preview_link**: *string*
 
-*Defined in [src/types.ts:178](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L178)*
+*Defined in [src/types.ts:186](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L186)*
 
 url of the content preview (json file containing list of files)
 
@@ -76,7 +76,7 @@ ___
 
 • **description**: *string*
 
-*Defined in [src/types.ts:186](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L186)*
+*Defined in [src/types.ts:194](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L194)*
 
 file description
 
@@ -86,7 +86,7 @@ ___
 
 • **external_virus_scan_url**: *string*
 
-*Defined in [src/types.ts:219](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L219)*
+*Defined in [src/types.ts:227](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L227)*
 
 link to the virus scan results
 null if there is none
@@ -97,7 +97,7 @@ ___
 
 • **file_id**: *number*
 
-*Defined in [src/types.ts:161](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L161)*
+*Defined in [src/types.ts:169](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L169)*
 
 file id
 
@@ -107,7 +107,7 @@ ___
 
 • **file_name**: *string*
 
-*Defined in [src/types.ts:202](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L202)*
+*Defined in [src/types.ts:210](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L210)*
 
 actual file name (derived from name with id and version appended)
 
@@ -117,7 +117,7 @@ ___
 
 • **is_primary**: *boolean*
 
-*Defined in [src/types.ts:224](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L224)*
+*Defined in [src/types.ts:232](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L232)*
 
 whether this is the primary download for the mod
 (the one that users download through the link in the top right of the mod page)
@@ -128,7 +128,7 @@ ___
 
 • **mod_version**: *string*
 
-*Defined in [src/types.ts:214](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L214)*
+*Defined in [src/types.ts:222](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L222)*
 
 version of the mod (at the time this was uploaded?)
 
@@ -138,7 +138,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:182](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L182)*
+*Defined in [src/types.ts:190](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L190)*
 
 readable file name
 
@@ -148,7 +148,7 @@ ___
 
 • **size**: *number*
 
-*Defined in [src/types.ts:194](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L194)*
+*Defined in [src/types.ts:202](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L202)*
 
 File size in kilobytes
 
@@ -158,7 +158,7 @@ ___
 
 • **size_kb**: *number*
 
-*Defined in [src/types.ts:198](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L198)*
+*Defined in [src/types.ts:206](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L206)*
 
 File size. also in kilobytes. Because - ugh, don't ask
 
@@ -168,7 +168,7 @@ ___
 
 • **uploaded_time**: *string*
 
-*Defined in [src/types.ts:210](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L210)*
+*Defined in [src/types.ts:218](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L218)*
 
 readable representation of the file time
 
@@ -178,7 +178,7 @@ ___
 
 • **uploaded_timestamp**: *number*
 
-*Defined in [src/types.ts:206](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L206)*
+*Defined in [src/types.ts:214](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L214)*
 
 unix timestamp of the time this file was uploaded
 
@@ -188,6 +188,6 @@ ___
 
 • **version**: *string*
 
-*Defined in [src/types.ts:190](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L190)*
+*Defined in [src/types.ts:198](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L198)*
 
 File version (doesn't actually have to match any mod version)

--- a/docs/interfaces/_types_.ifileinfo.md
+++ b/docs/interfaces/_types_.ifileinfo.md
@@ -35,7 +35,7 @@ Information about a specific mod file
 
 • **category_id**: *number*
 
-*Defined in [src/types.ts:173](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L173)*
+*Defined in [src/types.ts:173](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L173)*
 
 File type as a number (1 = main, 2 = patch, 3 = optional, 4 = old, 6 = deleted)
 
@@ -45,7 +45,7 @@ ___
 
 • **category_name**: *string*
 
-*Defined in [src/types.ts:177](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L177)*
+*Defined in [src/types.ts:177](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L177)*
 
 File type as a string ('MAIN', 'PATCH', 'OPTION', 'OLD_VERSION', 'DELETED')
 
@@ -55,7 +55,7 @@ ___
 
 • **changelog_html**: *string*
 
-*Defined in [src/types.ts:182](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L182)*
+*Defined in [src/types.ts:182](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L182)*
 
 html encoded changelog (matched via file version)
 null if there is none
@@ -66,7 +66,7 @@ ___
 
 • **content_preview_link**: *string*
 
-*Defined in [src/types.ts:186](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L186)*
+*Defined in [src/types.ts:186](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L186)*
 
 url of the content preview (json file containing list of files)
 
@@ -76,7 +76,7 @@ ___
 
 • **description**: *string*
 
-*Defined in [src/types.ts:194](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L194)*
+*Defined in [src/types.ts:194](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L194)*
 
 file description
 
@@ -86,7 +86,7 @@ ___
 
 • **external_virus_scan_url**: *string*
 
-*Defined in [src/types.ts:227](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L227)*
+*Defined in [src/types.ts:227](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L227)*
 
 link to the virus scan results
 null if there is none
@@ -97,7 +97,7 @@ ___
 
 • **file_id**: *number*
 
-*Defined in [src/types.ts:169](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L169)*
+*Defined in [src/types.ts:169](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L169)*
 
 file id
 
@@ -107,7 +107,7 @@ ___
 
 • **file_name**: *string*
 
-*Defined in [src/types.ts:210](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L210)*
+*Defined in [src/types.ts:210](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L210)*
 
 actual file name (derived from name with id and version appended)
 
@@ -117,7 +117,7 @@ ___
 
 • **is_primary**: *boolean*
 
-*Defined in [src/types.ts:232](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L232)*
+*Defined in [src/types.ts:232](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L232)*
 
 whether this is the primary download for the mod
 (the one that users download through the link in the top right of the mod page)
@@ -128,7 +128,7 @@ ___
 
 • **mod_version**: *string*
 
-*Defined in [src/types.ts:222](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L222)*
+*Defined in [src/types.ts:222](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L222)*
 
 version of the mod (at the time this was uploaded?)
 
@@ -138,7 +138,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:190](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L190)*
+*Defined in [src/types.ts:190](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L190)*
 
 readable file name
 
@@ -148,7 +148,7 @@ ___
 
 • **size**: *number*
 
-*Defined in [src/types.ts:202](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L202)*
+*Defined in [src/types.ts:202](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L202)*
 
 File size in kilobytes
 
@@ -158,7 +158,7 @@ ___
 
 • **size_kb**: *number*
 
-*Defined in [src/types.ts:206](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L206)*
+*Defined in [src/types.ts:206](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L206)*
 
 File size. also in kilobytes. Because - ugh, don't ask
 
@@ -168,7 +168,7 @@ ___
 
 • **uploaded_time**: *string*
 
-*Defined in [src/types.ts:218](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L218)*
+*Defined in [src/types.ts:218](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L218)*
 
 readable representation of the file time
 
@@ -178,7 +178,7 @@ ___
 
 • **uploaded_timestamp**: *number*
 
-*Defined in [src/types.ts:214](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L214)*
+*Defined in [src/types.ts:214](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L214)*
 
 unix timestamp of the time this file was uploaded
 
@@ -188,6 +188,6 @@ ___
 
 • **version**: *string*
 
-*Defined in [src/types.ts:198](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L198)*
+*Defined in [src/types.ts:198](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L198)*
 
 File version (doesn't actually have to match any mod version)

--- a/docs/interfaces/_types_.ifileupdate.md
+++ b/docs/interfaces/_types_.ifileupdate.md
@@ -27,7 +27,7 @@ a newer version of ...".
 
 • **new_file_id**: *number*
 
-*Defined in [src/types.ts:258](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L258)*
+*Defined in [src/types.ts:258](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L258)*
 
 id of the new file
 
@@ -37,7 +37,7 @@ ___
 
 • **new_file_name**: *string*
 
-*Defined in [src/types.ts:262](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L262)*
+*Defined in [src/types.ts:262](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L262)*
 
 name of the new file
 
@@ -47,7 +47,7 @@ ___
 
 • **old_file_id**: *number*
 
-*Defined in [src/types.ts:266](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L266)*
+*Defined in [src/types.ts:266](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L266)*
 
 id of the old file
 
@@ -57,7 +57,7 @@ ___
 
 • **old_file_name**: *string*
 
-*Defined in [src/types.ts:270](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L270)*
+*Defined in [src/types.ts:270](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L270)*
 
 name of the old file
 
@@ -67,7 +67,7 @@ ___
 
 • **uploaded_time**: *string*
 
-*Defined in [src/types.ts:274](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L274)*
+*Defined in [src/types.ts:274](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L274)*
 
 readable upload time of the new file
 
@@ -77,6 +77,6 @@ ___
 
 • **uploaded_timestamp**: *number*
 
-*Defined in [src/types.ts:278](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L278)*
+*Defined in [src/types.ts:278](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L278)*
 
 unix timestamp of when the new file was uploaded

--- a/docs/interfaces/_types_.ifileupdate.md
+++ b/docs/interfaces/_types_.ifileupdate.md
@@ -27,7 +27,7 @@ a newer version of ...".
 
 • **new_file_id**: *number*
 
-*Defined in [src/types.ts:250](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L250)*
+*Defined in [src/types.ts:258](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L258)*
 
 id of the new file
 
@@ -37,7 +37,7 @@ ___
 
 • **new_file_name**: *string*
 
-*Defined in [src/types.ts:254](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L254)*
+*Defined in [src/types.ts:262](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L262)*
 
 name of the new file
 
@@ -47,7 +47,7 @@ ___
 
 • **old_file_id**: *number*
 
-*Defined in [src/types.ts:258](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L258)*
+*Defined in [src/types.ts:266](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L266)*
 
 id of the old file
 
@@ -57,7 +57,7 @@ ___
 
 • **old_file_name**: *string*
 
-*Defined in [src/types.ts:262](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L262)*
+*Defined in [src/types.ts:270](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L270)*
 
 name of the old file
 
@@ -67,7 +67,7 @@ ___
 
 • **uploaded_time**: *string*
 
-*Defined in [src/types.ts:266](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L266)*
+*Defined in [src/types.ts:274](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L274)*
 
 readable upload time of the new file
 
@@ -77,6 +77,6 @@ ___
 
 • **uploaded_timestamp**: *number*
 
-*Defined in [src/types.ts:270](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L270)*
+*Defined in [src/types.ts:278](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L278)*
 
 unix timestamp of when the new file was uploaded

--- a/docs/interfaces/_types_.igameinfo.md
+++ b/docs/interfaces/_types_.igameinfo.md
@@ -34,7 +34,7 @@ extended information about a game
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[approved_date](_types_.igamelistentry.md#approved_date)*
 
-*Defined in [src/types.ts:347](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L347)*
+*Defined in [src/types.ts:347](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L347)*
 
 unix timestamp of when this game was added to nexuis mods
 
@@ -44,7 +44,7 @@ ___
 
 • **categories**: *[ICategory](_types_.icategory.md)[]*
 
-*Defined in [src/types.ts:357](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L357)*
+*Defined in [src/types.ts:357](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L357)*
 
 list of categories for this game
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[domain_name](_types_.igamelistentry.md#domain_name)*
 
-*Defined in [src/types.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L314)*
+*Defined in [src/types.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L314)*
 
 domain name (as used in urls and as the game id in all other requests)
 
@@ -68,7 +68,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[downloads](_types_.igamelistentry.md#downloads)*
 
-*Defined in [src/types.ts:343](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L343)*
+*Defined in [src/types.ts:343](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L343)*
 
 number of downloads from nexus for files for this game
 
@@ -80,7 +80,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[file_count](_types_.igamelistentry.md#file_count)*
 
-*Defined in [src/types.ts:339](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L339)*
+*Defined in [src/types.ts:339](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L339)*
 
 number of files hosted on nexus for this game
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[forum_url](_types_.igamelistentry.md#forum_url)*
 
-*Defined in [src/types.ts:322](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L322)*
+*Defined in [src/types.ts:322](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L322)*
 
 url for the corresponding forum section
 
@@ -104,7 +104,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[genre](_types_.igamelistentry.md#genre)*
 
-*Defined in [src/types.ts:331](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L331)*
+*Defined in [src/types.ts:331](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L331)*
 
 genre of the game
 (possible values?)
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[id](_types_.igamelistentry.md#id)*
 
-*Defined in [src/types.ts:310](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L310)*
+*Defined in [src/types.ts:310](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L310)*
 
 numerical id
 
@@ -129,7 +129,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[mods](_types_.igamelistentry.md#mods)*
 
-*Defined in [src/types.ts:335](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L335)*
+*Defined in [src/types.ts:335](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L335)*
 
 number of mods hosted on nexus for this game
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[name](_types_.igamelistentry.md#name)*
 
-*Defined in [src/types.ts:318](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L318)*
+*Defined in [src/types.ts:318](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L318)*
 
 display name
 
@@ -153,6 +153,6 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[nexusmods_url](_types_.igamelistentry.md#nexusmods_url)*
 
-*Defined in [src/types.ts:326](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L326)*
+*Defined in [src/types.ts:326](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L326)*
 
 url for the primary nexusmods page (should be https://www.nexusmods.com/<domain_name>)

--- a/docs/interfaces/_types_.igameinfo.md
+++ b/docs/interfaces/_types_.igameinfo.md
@@ -34,7 +34,7 @@ extended information about a game
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[approved_date](_types_.igamelistentry.md#approved_date)*
 
-*Defined in [src/types.ts:339](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L339)*
+*Defined in [src/types.ts:347](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L347)*
 
 unix timestamp of when this game was added to nexuis mods
 
@@ -44,7 +44,7 @@ ___
 
 • **categories**: *[ICategory](_types_.icategory.md)[]*
 
-*Defined in [src/types.ts:349](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L349)*
+*Defined in [src/types.ts:357](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L357)*
 
 list of categories for this game
 
@@ -56,7 +56,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[domain_name](_types_.igamelistentry.md#domain_name)*
 
-*Defined in [src/types.ts:306](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L306)*
+*Defined in [src/types.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L314)*
 
 domain name (as used in urls and as the game id in all other requests)
 
@@ -68,7 +68,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[downloads](_types_.igamelistentry.md#downloads)*
 
-*Defined in [src/types.ts:335](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L335)*
+*Defined in [src/types.ts:343](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L343)*
 
 number of downloads from nexus for files for this game
 
@@ -80,7 +80,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[file_count](_types_.igamelistentry.md#file_count)*
 
-*Defined in [src/types.ts:331](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L331)*
+*Defined in [src/types.ts:339](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L339)*
 
 number of files hosted on nexus for this game
 
@@ -92,7 +92,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[forum_url](_types_.igamelistentry.md#forum_url)*
 
-*Defined in [src/types.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L314)*
+*Defined in [src/types.ts:322](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L322)*
 
 url for the corresponding forum section
 
@@ -104,7 +104,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[genre](_types_.igamelistentry.md#genre)*
 
-*Defined in [src/types.ts:323](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L323)*
+*Defined in [src/types.ts:331](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L331)*
 
 genre of the game
 (possible values?)
@@ -117,7 +117,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[id](_types_.igamelistentry.md#id)*
 
-*Defined in [src/types.ts:302](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L302)*
+*Defined in [src/types.ts:310](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L310)*
 
 numerical id
 
@@ -129,7 +129,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[mods](_types_.igamelistentry.md#mods)*
 
-*Defined in [src/types.ts:327](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L327)*
+*Defined in [src/types.ts:335](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L335)*
 
 number of mods hosted on nexus for this game
 
@@ -141,7 +141,7 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[name](_types_.igamelistentry.md#name)*
 
-*Defined in [src/types.ts:310](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L310)*
+*Defined in [src/types.ts:318](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L318)*
 
 display name
 
@@ -153,6 +153,6 @@ ___
 
 *Inherited from [IGameListEntry](_types_.igamelistentry.md).[nexusmods_url](_types_.igamelistentry.md#nexusmods_url)*
 
-*Defined in [src/types.ts:318](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L318)*
+*Defined in [src/types.ts:326](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L326)*
 
 url for the primary nexusmods page (should be https://www.nexusmods.com/<domain_name>)

--- a/docs/interfaces/_types_.igamelistentry.md
+++ b/docs/interfaces/_types_.igamelistentry.md
@@ -31,7 +31,7 @@ basic information about a game
 
 • **approved_date**: *number*
 
-*Defined in [src/types.ts:347](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L347)*
+*Defined in [src/types.ts:347](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L347)*
 
 unix timestamp of when this game was added to nexuis mods
 
@@ -41,7 +41,7 @@ ___
 
 • **domain_name**: *string*
 
-*Defined in [src/types.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L314)*
+*Defined in [src/types.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L314)*
 
 domain name (as used in urls and as the game id in all other requests)
 
@@ -51,7 +51,7 @@ ___
 
 • **downloads**: *number*
 
-*Defined in [src/types.ts:343](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L343)*
+*Defined in [src/types.ts:343](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L343)*
 
 number of downloads from nexus for files for this game
 
@@ -61,7 +61,7 @@ ___
 
 • **file_count**: *number*
 
-*Defined in [src/types.ts:339](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L339)*
+*Defined in [src/types.ts:339](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L339)*
 
 number of files hosted on nexus for this game
 
@@ -71,7 +71,7 @@ ___
 
 • **forum_url**: *string*
 
-*Defined in [src/types.ts:322](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L322)*
+*Defined in [src/types.ts:322](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L322)*
 
 url for the corresponding forum section
 
@@ -81,7 +81,7 @@ ___
 
 • **genre**: *string*
 
-*Defined in [src/types.ts:331](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L331)*
+*Defined in [src/types.ts:331](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L331)*
 
 genre of the game
 (possible values?)
@@ -92,7 +92,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types.ts:310](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L310)*
+*Defined in [src/types.ts:310](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L310)*
 
 numerical id
 
@@ -102,7 +102,7 @@ ___
 
 • **mods**: *number*
 
-*Defined in [src/types.ts:335](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L335)*
+*Defined in [src/types.ts:335](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L335)*
 
 number of mods hosted on nexus for this game
 
@@ -112,7 +112,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:318](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L318)*
+*Defined in [src/types.ts:318](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L318)*
 
 display name
 
@@ -122,6 +122,6 @@ ___
 
 • **nexusmods_url**: *string*
 
-*Defined in [src/types.ts:326](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L326)*
+*Defined in [src/types.ts:326](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L326)*
 
 url for the primary nexusmods page (should be https://www.nexusmods.com/<domain_name>)

--- a/docs/interfaces/_types_.igamelistentry.md
+++ b/docs/interfaces/_types_.igamelistentry.md
@@ -31,7 +31,7 @@ basic information about a game
 
 • **approved_date**: *number*
 
-*Defined in [src/types.ts:339](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L339)*
+*Defined in [src/types.ts:347](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L347)*
 
 unix timestamp of when this game was added to nexuis mods
 
@@ -41,7 +41,7 @@ ___
 
 • **domain_name**: *string*
 
-*Defined in [src/types.ts:306](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L306)*
+*Defined in [src/types.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L314)*
 
 domain name (as used in urls and as the game id in all other requests)
 
@@ -51,7 +51,7 @@ ___
 
 • **downloads**: *number*
 
-*Defined in [src/types.ts:335](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L335)*
+*Defined in [src/types.ts:343](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L343)*
 
 number of downloads from nexus for files for this game
 
@@ -61,7 +61,7 @@ ___
 
 • **file_count**: *number*
 
-*Defined in [src/types.ts:331](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L331)*
+*Defined in [src/types.ts:339](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L339)*
 
 number of files hosted on nexus for this game
 
@@ -71,7 +71,7 @@ ___
 
 • **forum_url**: *string*
 
-*Defined in [src/types.ts:314](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L314)*
+*Defined in [src/types.ts:322](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L322)*
 
 url for the corresponding forum section
 
@@ -81,7 +81,7 @@ ___
 
 • **genre**: *string*
 
-*Defined in [src/types.ts:323](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L323)*
+*Defined in [src/types.ts:331](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L331)*
 
 genre of the game
 (possible values?)
@@ -92,7 +92,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types.ts:302](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L302)*
+*Defined in [src/types.ts:310](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L310)*
 
 numerical id
 
@@ -102,7 +102,7 @@ ___
 
 • **mods**: *number*
 
-*Defined in [src/types.ts:327](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L327)*
+*Defined in [src/types.ts:335](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L335)*
 
 number of mods hosted on nexus for this game
 
@@ -112,7 +112,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:310](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L310)*
+*Defined in [src/types.ts:318](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L318)*
 
 display name
 
@@ -122,6 +122,6 @@ ___
 
 • **nexusmods_url**: *string*
 
-*Defined in [src/types.ts:318](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L318)*
+*Defined in [src/types.ts:326](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L326)*
 
 url for the primary nexusmods page (should be https://www.nexusmods.com/<domain_name>)

--- a/docs/interfaces/_types_.igithubissue.md
+++ b/docs/interfaces/_types_.igithubissue.md
@@ -27,7 +27,7 @@ INTERNAL USE ONLY
 
 • **created_at**: *string*
 
-*Defined in [src/types.ts:406](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L406)*
+*Defined in [src/types.ts:414](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L414)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **grouping_key**: *string*
 
-*Defined in [src/types.ts:405](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L405)*
+*Defined in [src/types.ts:413](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L413)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types.ts:401](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L401)*
+*Defined in [src/types.ts:409](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L409)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 • **issue_number**: *number*
 
-*Defined in [src/types.ts:402](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L402)*
+*Defined in [src/types.ts:410](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L410)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **issue_state**: *string*
 
-*Defined in [src/types.ts:404](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L404)*
+*Defined in [src/types.ts:412](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L412)*
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 • **issue_title**: *string*
 
-*Defined in [src/types.ts:403](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L403)*
+*Defined in [src/types.ts:411](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L411)*
 
 ___
 
@@ -75,4 +75,4 @@ ___
 
 • **updated_at**: *string*
 
-*Defined in [src/types.ts:407](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L407)*
+*Defined in [src/types.ts:415](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L415)*

--- a/docs/interfaces/_types_.igithubissue.md
+++ b/docs/interfaces/_types_.igithubissue.md
@@ -27,7 +27,7 @@ INTERNAL USE ONLY
 
 • **created_at**: *string*
 
-*Defined in [src/types.ts:414](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L414)*
+*Defined in [src/types.ts:414](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L414)*
 
 ___
 
@@ -35,7 +35,7 @@ ___
 
 • **grouping_key**: *string*
 
-*Defined in [src/types.ts:413](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L413)*
+*Defined in [src/types.ts:413](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L413)*
 
 ___
 
@@ -43,7 +43,7 @@ ___
 
 • **id**: *number*
 
-*Defined in [src/types.ts:409](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L409)*
+*Defined in [src/types.ts:409](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L409)*
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 • **issue_number**: *number*
 
-*Defined in [src/types.ts:410](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L410)*
+*Defined in [src/types.ts:410](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L410)*
 
 ___
 
@@ -59,7 +59,7 @@ ___
 
 • **issue_state**: *string*
 
-*Defined in [src/types.ts:412](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L412)*
+*Defined in [src/types.ts:412](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L412)*
 
 ___
 
@@ -67,7 +67,7 @@ ___
 
 • **issue_title**: *string*
 
-*Defined in [src/types.ts:411](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L411)*
+*Defined in [src/types.ts:411](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L411)*
 
 ___
 
@@ -75,4 +75,4 @@ ___
 
 • **updated_at**: *string*
 
-*Defined in [src/types.ts:415](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L415)*
+*Defined in [src/types.ts:415](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L415)*

--- a/docs/interfaces/_types_.iissue.md
+++ b/docs/interfaces/_types_.iissue.md
@@ -24,7 +24,7 @@ INTERNAL USE ONLY
 
 • **id**: *number*
 
-*Defined in [src/types.ts:398](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L398)*
+*Defined in [src/types.ts:398](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L398)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **issue_number**: *number*
 
-*Defined in [src/types.ts:399](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L399)*
+*Defined in [src/types.ts:399](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L399)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **issue_state**: *string*
 
-*Defined in [src/types.ts:400](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L400)*
+*Defined in [src/types.ts:400](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L400)*
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 • **issue_title**: *string*
 
-*Defined in [src/types.ts:401](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L401)*
+*Defined in [src/types.ts:401](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L401)*

--- a/docs/interfaces/_types_.iissue.md
+++ b/docs/interfaces/_types_.iissue.md
@@ -24,7 +24,7 @@ INTERNAL USE ONLY
 
 • **id**: *number*
 
-*Defined in [src/types.ts:390](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L390)*
+*Defined in [src/types.ts:398](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L398)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **issue_number**: *number*
 
-*Defined in [src/types.ts:391](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L391)*
+*Defined in [src/types.ts:399](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L399)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **issue_state**: *string*
 
-*Defined in [src/types.ts:392](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L392)*
+*Defined in [src/types.ts:400](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L400)*
 
 ___
 
@@ -48,4 +48,4 @@ ___
 
 • **issue_title**: *string*
 
-*Defined in [src/types.ts:393](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L393)*
+*Defined in [src/types.ts:401](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L401)*

--- a/docs/interfaces/_types_.imd5result.md
+++ b/docs/interfaces/_types_.imd5result.md
@@ -21,7 +21,7 @@ Result from a md5 lookup
 
 • **file_details**: *[IFileInfo](_types_.ifileinfo.md)*
 
-*Defined in [src/types.ts:390](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L390)*
+*Defined in [src/types.ts:390](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L390)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • **mod**: *[IModInfoEx](_types_.imodinfoex.md)*
 
-*Defined in [src/types.ts:389](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L389)*
+*Defined in [src/types.ts:389](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L389)*

--- a/docs/interfaces/_types_.imd5result.md
+++ b/docs/interfaces/_types_.imd5result.md
@@ -21,7 +21,7 @@ Result from a md5 lookup
 
 • **file_details**: *[IFileInfo](_types_.ifileinfo.md)*
 
-*Defined in [src/types.ts:382](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L382)*
+*Defined in [src/types.ts:390](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L390)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • **mod**: *[IModInfoEx](_types_.imodinfoex.md)*
 
-*Defined in [src/types.ts:381](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L381)*
+*Defined in [src/types.ts:389](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L389)*

--- a/docs/interfaces/_types_.imodfiles.md
+++ b/docs/interfaces/_types_.imodfiles.md
@@ -21,7 +21,7 @@ list of files (and update chain) associated with a mod
 
 • **file_updates**: *[IFileUpdate](_types_.ifileupdate.md)[]*
 
-*Defined in [src/types.ts:242](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L242)*
+*Defined in [src/types.ts:242](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L242)*
 
 list of file updates stored with a mod
 
@@ -31,6 +31,6 @@ ___
 
 • **files**: *[IFileInfo](_types_.ifileinfo.md)[]*
 
-*Defined in [src/types.ts:246](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L246)*
+*Defined in [src/types.ts:246](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L246)*
 
 list of files stored for a mod

--- a/docs/interfaces/_types_.imodfiles.md
+++ b/docs/interfaces/_types_.imodfiles.md
@@ -21,7 +21,7 @@ list of files (and update chain) associated with a mod
 
 • **file_updates**: *[IFileUpdate](_types_.ifileupdate.md)[]*
 
-*Defined in [src/types.ts:234](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L234)*
+*Defined in [src/types.ts:242](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L242)*
 
 list of file updates stored with a mod
 
@@ -31,6 +31,6 @@ ___
 
 • **files**: *[IFileInfo](_types_.ifileinfo.md)[]*
 
-*Defined in [src/types.ts:238](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L238)*
+*Defined in [src/types.ts:246](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L246)*
 
 list of files stored for a mod

--- a/docs/interfaces/_types_.imodinfo.md
+++ b/docs/interfaces/_types_.imodinfo.md
@@ -26,7 +26,9 @@ Details about a mod
 * [endorsement](_types_.imodinfo.md#optional-endorsement)
 * [endorsement_count](_types_.imodinfo.md#endorsement_count)
 * [game_id](_types_.imodinfo.md#game_id)
+* [mod_downloads](_types_.imodinfo.md#mod_downloads)
 * [mod_id](_types_.imodinfo.md#mod_id)
+* [mod_unique_downloads](_types_.imodinfo.md#mod_unique_downloads)
 * [name](_types_.imodinfo.md#optional-name)
 * [picture_url](_types_.imodinfo.md#optional-picture_url)
 * [status](_types_.imodinfo.md#status)
@@ -44,7 +46,7 @@ Details about a mod
 
 • **allow_rating**: *boolean*
 
-*Defined in [src/types.ts:139](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L139)*
+*Defined in [src/types.ts:147](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L147)*
 
 whether this mod allows endorsements
 
@@ -97,7 +99,7 @@ ___
 
 • **created_time**: *string*
 
-*Defined in [src/types.ts:127](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L127)*
+*Defined in [src/types.ts:135](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L135)*
 
 readable time of when the mod was created
 
@@ -107,7 +109,7 @@ ___
 
 • **created_timestamp**: *number*
 
-*Defined in [src/types.ts:123](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L123)*
+*Defined in [src/types.ts:131](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L131)*
 
 unix timestamp of when the mod was created
 
@@ -137,7 +139,7 @@ ___
 
 • **endorsement**? : *object*
 
-*Defined in [src/types.ts:147](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L147)*
+*Defined in [src/types.ts:155](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L155)*
 
 obsolete - will be removed in the near future
 
@@ -155,7 +157,7 @@ ___
 
 • **endorsement_count**: *number*
 
-*Defined in [src/types.ts:143](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L143)*
+*Defined in [src/types.ts:151](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L151)*
 
 endorsement count
 
@@ -171,6 +173,16 @@ internal id of the game this mod belongs to
 
 ___
 
+###  mod_downloads
+
+• **mod_downloads**: *number*
+
+*Defined in [src/types.ts:123](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L123)*
+
+download count
+
+___
+
 ###  mod_id
 
 • **mod_id**: *number*
@@ -178,6 +190,16 @@ ___
 *Defined in [src/types.ts:55](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L55)*
 
 id of this mod (should be the same you queried for)
+
+___
+
+###  mod_unique_downloads
+
+• **mod_unique_downloads**: *number*
+
+*Defined in [src/types.ts:127](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L127)*
+
+unique download count
 
 ___
 
@@ -226,7 +248,7 @@ ___
 
 • **updated_time**: *string*
 
-*Defined in [src/types.ts:135](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L135)*
+*Defined in [src/types.ts:143](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L143)*
 
 readable time of when the mod was updated
 
@@ -236,7 +258,7 @@ ___
 
 • **updated_timestamp**: *number*
 
-*Defined in [src/types.ts:131](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L131)*
+*Defined in [src/types.ts:139](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L139)*
 
 unix timestamp of when the mod was updated
 

--- a/docs/interfaces/_types_.imodinfo.md
+++ b/docs/interfaces/_types_.imodinfo.md
@@ -46,7 +46,7 @@ Details about a mod
 
 • **allow_rating**: *boolean*
 
-*Defined in [src/types.ts:147](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L147)*
+*Defined in [src/types.ts:147](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L147)*
 
 whether this mod allows endorsements
 
@@ -56,7 +56,7 @@ ___
 
 • **author**: *string*
 
-*Defined in [src/types.ts:92](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L92)*
+*Defined in [src/types.ts:92](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L92)*
 
 Author of the mod
 
@@ -66,7 +66,7 @@ ___
 
 • **available**: *boolean*
 
-*Defined in [src/types.ts:115](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L115)*
+*Defined in [src/types.ts:115](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L115)*
 
 whether the mod is currently available/visible to users
 If a mod isn't available the api returns very limited information, essentially
@@ -79,7 +79,7 @@ ___
 
 • **category_id**: *number*
 
-*Defined in [src/types.ts:67](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L67)*
+*Defined in [src/types.ts:67](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L67)*
 
 id of the category
 
@@ -89,7 +89,7 @@ ___
 
 • **contains_adult_content**: *boolean*
 
-*Defined in [src/types.ts:71](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L71)*
+*Defined in [src/types.ts:71](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L71)*
 
 whether this mod is tagged as adult
 
@@ -99,7 +99,7 @@ ___
 
 • **created_time**: *string*
 
-*Defined in [src/types.ts:135](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L135)*
+*Defined in [src/types.ts:135](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L135)*
 
 readable time of when the mod was created
 
@@ -109,7 +109,7 @@ ___
 
 • **created_timestamp**: *number*
 
-*Defined in [src/types.ts:131](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L131)*
+*Defined in [src/types.ts:131](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L131)*
 
 unix timestamp of when the mod was created
 
@@ -119,7 +119,7 @@ ___
 
 • **description**? : *string*
 
-*Defined in [src/types.ts:84](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L84)*
+*Defined in [src/types.ts:84](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L84)*
 
 long description (bbcode)
 
@@ -129,7 +129,7 @@ ___
 
 • **domain_name**: *string*
 
-*Defined in [src/types.ts:63](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L63)*
+*Defined in [src/types.ts:63](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L63)*
 
 domain name (as used in urls and as the game id in all other requests)
 
@@ -139,7 +139,7 @@ ___
 
 • **endorsement**? : *object*
 
-*Defined in [src/types.ts:155](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L155)*
+*Defined in [src/types.ts:155](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L155)*
 
 obsolete - will be removed in the near future
 
@@ -157,7 +157,7 @@ ___
 
 • **endorsement_count**: *number*
 
-*Defined in [src/types.ts:151](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L151)*
+*Defined in [src/types.ts:151](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L151)*
 
 endorsement count
 
@@ -167,7 +167,7 @@ ___
 
 • **game_id**: *number*
 
-*Defined in [src/types.ts:59](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L59)*
+*Defined in [src/types.ts:59](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L59)*
 
 internal id of the game this mod belongs to
 
@@ -177,7 +177,7 @@ ___
 
 • **mod_downloads**: *number*
 
-*Defined in [src/types.ts:123](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L123)*
+*Defined in [src/types.ts:123](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L123)*
 
 download count
 
@@ -187,7 +187,7 @@ ___
 
 • **mod_id**: *number*
 
-*Defined in [src/types.ts:55](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L55)*
+*Defined in [src/types.ts:55](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L55)*
 
 id of this mod (should be the same you queried for)
 
@@ -197,7 +197,7 @@ ___
 
 • **mod_unique_downloads**: *number*
 
-*Defined in [src/types.ts:127](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L127)*
+*Defined in [src/types.ts:127](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L127)*
 
 unique download count
 
@@ -207,7 +207,7 @@ ___
 
 • **name**? : *string*
 
-*Defined in [src/types.ts:76](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L76)*
+*Defined in [src/types.ts:76](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L76)*
 
 Name of the mod
 (not present if the file is under moderation)
@@ -218,7 +218,7 @@ ___
 
 • **picture_url**? : *string*
 
-*Defined in [src/types.ts:119](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L119)*
+*Defined in [src/types.ts:119](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L119)*
 
 url of the primary screenshot
 
@@ -228,7 +228,7 @@ ___
 
 • **status**: *[ModStatus](../modules/_types_.md#modstatus)*
 
-*Defined in [src/types.ts:108](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L108)*
+*Defined in [src/types.ts:108](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L108)*
 
 current status of the mod
 
@@ -238,7 +238,7 @@ ___
 
 • **summary**? : *string*
 
-*Defined in [src/types.ts:80](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L80)*
+*Defined in [src/types.ts:80](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L80)*
 
 short description
 
@@ -248,7 +248,7 @@ ___
 
 • **updated_time**: *string*
 
-*Defined in [src/types.ts:143](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L143)*
+*Defined in [src/types.ts:143](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L143)*
 
 readable time of when the mod was updated
 
@@ -258,7 +258,7 @@ ___
 
 • **updated_timestamp**: *number*
 
-*Defined in [src/types.ts:139](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L139)*
+*Defined in [src/types.ts:139](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L139)*
 
 unix timestamp of when the mod was updated
 
@@ -268,7 +268,7 @@ ___
 
 • **uploaded_by**: *string*
 
-*Defined in [src/types.ts:100](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L100)*
+*Defined in [src/types.ts:100](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L100)*
 
 name of the user who uploaded this mod
 
@@ -278,7 +278,7 @@ ___
 
 • **uploaded_users_profile_url**: *string*
 
-*Defined in [src/types.ts:104](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L104)*
+*Defined in [src/types.ts:104](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L104)*
 
 url of the profile image of the uploader
 
@@ -288,7 +288,7 @@ ___
 
 • **user**: *[IUser](_types_.iuser.md)*
 
-*Defined in [src/types.ts:96](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L96)*
+*Defined in [src/types.ts:96](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L96)*
 
 more detailed info about the author
 
@@ -298,6 +298,6 @@ ___
 
 • **version**: *string*
 
-*Defined in [src/types.ts:88](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L88)*
+*Defined in [src/types.ts:88](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L88)*
 
 mod version

--- a/docs/interfaces/_types_.imodinfoex.md
+++ b/docs/interfaces/_types_.imodinfoex.md
@@ -46,7 +46,7 @@
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[allow_rating](_types_.imodinfo.md#allow_rating)*
 
-*Defined in [src/types.ts:147](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L147)*
+*Defined in [src/types.ts:147](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L147)*
 
 whether this mod allows endorsements
 
@@ -58,7 +58,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[author](_types_.imodinfo.md#author)*
 
-*Defined in [src/types.ts:92](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L92)*
+*Defined in [src/types.ts:92](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L92)*
 
 Author of the mod
 
@@ -70,7 +70,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[available](_types_.imodinfo.md#available)*
 
-*Defined in [src/types.ts:115](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L115)*
+*Defined in [src/types.ts:115](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L115)*
 
 whether the mod is currently available/visible to users
 If a mod isn't available the api returns very limited information, essentially
@@ -85,7 +85,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[category_id](_types_.imodinfo.md#category_id)*
 
-*Defined in [src/types.ts:67](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L67)*
+*Defined in [src/types.ts:67](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L67)*
 
 id of the category
 
@@ -97,7 +97,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[contains_adult_content](_types_.imodinfo.md#contains_adult_content)*
 
-*Defined in [src/types.ts:71](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L71)*
+*Defined in [src/types.ts:71](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L71)*
 
 whether this mod is tagged as adult
 
@@ -109,7 +109,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[created_time](_types_.imodinfo.md#created_time)*
 
-*Defined in [src/types.ts:135](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L135)*
+*Defined in [src/types.ts:135](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L135)*
 
 readable time of when the mod was created
 
@@ -121,7 +121,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[created_timestamp](_types_.imodinfo.md#created_timestamp)*
 
-*Defined in [src/types.ts:131](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L131)*
+*Defined in [src/types.ts:131](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L131)*
 
 unix timestamp of when the mod was created
 
@@ -133,7 +133,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[description](_types_.imodinfo.md#optional-description)*
 
-*Defined in [src/types.ts:84](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L84)*
+*Defined in [src/types.ts:84](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L84)*
 
 long description (bbcode)
 
@@ -145,7 +145,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[domain_name](_types_.imodinfo.md#domain_name)*
 
-*Defined in [src/types.ts:63](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L63)*
+*Defined in [src/types.ts:63](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L63)*
 
 domain name (as used in urls and as the game id in all other requests)
 
@@ -157,7 +157,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[endorsement](_types_.imodinfo.md#optional-endorsement)*
 
-*Defined in [src/types.ts:155](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L155)*
+*Defined in [src/types.ts:155](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L155)*
 
 obsolete - will be removed in the near future
 
@@ -177,7 +177,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[endorsement_count](_types_.imodinfo.md#endorsement_count)*
 
-*Defined in [src/types.ts:151](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L151)*
+*Defined in [src/types.ts:151](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L151)*
 
 endorsement count
 
@@ -189,7 +189,7 @@ ___
 
 *Overrides [IModInfo](_types_.imodinfo.md).[game_id](_types_.imodinfo.md#game_id)*
 
-*Defined in [src/types.ts:381](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L381)*
+*Defined in [src/types.ts:381](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L381)*
 
 ___
 
@@ -199,7 +199,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[mod_downloads](_types_.imodinfo.md#mod_downloads)*
 
-*Defined in [src/types.ts:123](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L123)*
+*Defined in [src/types.ts:123](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L123)*
 
 download count
 
@@ -211,7 +211,7 @@ ___
 
 *Overrides [IModInfo](_types_.imodinfo.md).[mod_id](_types_.imodinfo.md#mod_id)*
 
-*Defined in [src/types.ts:382](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L382)*
+*Defined in [src/types.ts:382](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L382)*
 
 ___
 
@@ -221,7 +221,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[mod_unique_downloads](_types_.imodinfo.md#mod_unique_downloads)*
 
-*Defined in [src/types.ts:127](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L127)*
+*Defined in [src/types.ts:127](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L127)*
 
 unique download count
 
@@ -233,7 +233,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[name](_types_.imodinfo.md#optional-name)*
 
-*Defined in [src/types.ts:76](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L76)*
+*Defined in [src/types.ts:76](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L76)*
 
 Name of the mod
 (not present if the file is under moderation)
@@ -246,7 +246,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[picture_url](_types_.imodinfo.md#optional-picture_url)*
 
-*Defined in [src/types.ts:119](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L119)*
+*Defined in [src/types.ts:119](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L119)*
 
 url of the primary screenshot
 
@@ -258,7 +258,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[status](_types_.imodinfo.md#status)*
 
-*Defined in [src/types.ts:108](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L108)*
+*Defined in [src/types.ts:108](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L108)*
 
 current status of the mod
 
@@ -270,7 +270,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[summary](_types_.imodinfo.md#optional-summary)*
 
-*Defined in [src/types.ts:80](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L80)*
+*Defined in [src/types.ts:80](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L80)*
 
 short description
 
@@ -282,7 +282,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[updated_time](_types_.imodinfo.md#updated_time)*
 
-*Defined in [src/types.ts:143](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L143)*
+*Defined in [src/types.ts:143](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L143)*
 
 readable time of when the mod was updated
 
@@ -294,7 +294,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[updated_timestamp](_types_.imodinfo.md#updated_timestamp)*
 
-*Defined in [src/types.ts:139](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L139)*
+*Defined in [src/types.ts:139](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L139)*
 
 unix timestamp of when the mod was updated
 
@@ -306,7 +306,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[uploaded_by](_types_.imodinfo.md#uploaded_by)*
 
-*Defined in [src/types.ts:100](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L100)*
+*Defined in [src/types.ts:100](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L100)*
 
 name of the user who uploaded this mod
 
@@ -318,7 +318,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[uploaded_users_profile_url](_types_.imodinfo.md#uploaded_users_profile_url)*
 
-*Defined in [src/types.ts:104](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L104)*
+*Defined in [src/types.ts:104](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L104)*
 
 url of the profile image of the uploader
 
@@ -330,7 +330,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[user](_types_.imodinfo.md#user)*
 
-*Defined in [src/types.ts:96](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L96)*
+*Defined in [src/types.ts:96](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L96)*
 
 more detailed info about the author
 
@@ -342,6 +342,6 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[version](_types_.imodinfo.md#version)*
 
-*Defined in [src/types.ts:88](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L88)*
+*Defined in [src/types.ts:88](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L88)*
 
 mod version

--- a/docs/interfaces/_types_.imodinfoex.md
+++ b/docs/interfaces/_types_.imodinfoex.md
@@ -24,7 +24,9 @@
 * [endorsement](_types_.imodinfoex.md#optional-endorsement)
 * [endorsement_count](_types_.imodinfoex.md#endorsement_count)
 * [game_id](_types_.imodinfoex.md#game_id)
+* [mod_downloads](_types_.imodinfoex.md#mod_downloads)
 * [mod_id](_types_.imodinfoex.md#mod_id)
+* [mod_unique_downloads](_types_.imodinfoex.md#mod_unique_downloads)
 * [name](_types_.imodinfoex.md#optional-name)
 * [picture_url](_types_.imodinfoex.md#optional-picture_url)
 * [status](_types_.imodinfoex.md#status)
@@ -44,7 +46,7 @@
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[allow_rating](_types_.imodinfo.md#allow_rating)*
 
-*Defined in [src/types.ts:139](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L139)*
+*Defined in [src/types.ts:147](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L147)*
 
 whether this mod allows endorsements
 
@@ -107,7 +109,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[created_time](_types_.imodinfo.md#created_time)*
 
-*Defined in [src/types.ts:127](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L127)*
+*Defined in [src/types.ts:135](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L135)*
 
 readable time of when the mod was created
 
@@ -119,7 +121,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[created_timestamp](_types_.imodinfo.md#created_timestamp)*
 
-*Defined in [src/types.ts:123](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L123)*
+*Defined in [src/types.ts:131](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L131)*
 
 unix timestamp of when the mod was created
 
@@ -155,7 +157,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[endorsement](_types_.imodinfo.md#optional-endorsement)*
 
-*Defined in [src/types.ts:147](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L147)*
+*Defined in [src/types.ts:155](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L155)*
 
 obsolete - will be removed in the near future
 
@@ -175,7 +177,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[endorsement_count](_types_.imodinfo.md#endorsement_count)*
 
-*Defined in [src/types.ts:143](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L143)*
+*Defined in [src/types.ts:151](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L151)*
 
 endorsement count
 
@@ -187,7 +189,19 @@ ___
 
 *Overrides [IModInfo](_types_.imodinfo.md).[game_id](_types_.imodinfo.md#game_id)*
 
-*Defined in [src/types.ts:374](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L374)*
+*Defined in [src/types.ts:381](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L381)*
+
+___
+
+###  mod_downloads
+
+• **mod_downloads**: *number*
+
+*Inherited from [IModInfo](_types_.imodinfo.md).[mod_downloads](_types_.imodinfo.md#mod_downloads)*
+
+*Defined in [src/types.ts:123](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L123)*
+
+download count
 
 ___
 
@@ -197,7 +211,19 @@ ___
 
 *Overrides [IModInfo](_types_.imodinfo.md).[mod_id](_types_.imodinfo.md#mod_id)*
 
-*Defined in [src/types.ts:373](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L373)*
+*Defined in [src/types.ts:382](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L382)*
+
+___
+
+###  mod_unique_downloads
+
+• **mod_unique_downloads**: *number*
+
+*Inherited from [IModInfo](_types_.imodinfo.md).[mod_unique_downloads](_types_.imodinfo.md#mod_unique_downloads)*
+
+*Defined in [src/types.ts:127](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L127)*
+
+unique download count
 
 ___
 
@@ -256,7 +282,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[updated_time](_types_.imodinfo.md#updated_time)*
 
-*Defined in [src/types.ts:135](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L135)*
+*Defined in [src/types.ts:143](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L143)*
 
 readable time of when the mod was updated
 
@@ -268,7 +294,7 @@ ___
 
 *Inherited from [IModInfo](_types_.imodinfo.md).[updated_timestamp](_types_.imodinfo.md#updated_timestamp)*
 
-*Defined in [src/types.ts:131](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L131)*
+*Defined in [src/types.ts:139](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L139)*
 
 unix timestamp of when the mod was updated
 

--- a/docs/interfaces/_types_.inexusevents.md
+++ b/docs/interfaces/_types_.inexusevents.md
@@ -18,7 +18,7 @@
 
 • **oauth-credentials-updated**: *function*
 
-*Defined in [src/types.ts:510](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L510)*
+*Defined in [src/types.ts:518](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L518)*
 
 #### Type declaration:
 

--- a/docs/interfaces/_types_.inexusevents.md
+++ b/docs/interfaces/_types_.inexusevents.md
@@ -18,7 +18,7 @@
 
 • **oauth-credentials-updated**: *function*
 
-*Defined in [src/types.ts:518](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L518)*
+*Defined in [src/types.ts:518](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L518)*
 
 #### Type declaration:
 

--- a/docs/interfaces/_types_.ioauthconfig.md
+++ b/docs/interfaces/_types_.ioauthconfig.md
@@ -19,7 +19,7 @@
 
 • **id**: *string*
 
-*Defined in [src/types.ts:505](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L505)*
+*Defined in [src/types.ts:513](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L513)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **secret**: *string*
 
-*Defined in [src/types.ts:506](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L506)*
+*Defined in [src/types.ts:514](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L514)*

--- a/docs/interfaces/_types_.ioauthconfig.md
+++ b/docs/interfaces/_types_.ioauthconfig.md
@@ -19,7 +19,7 @@
 
 • **id**: *string*
 
-*Defined in [src/types.ts:513](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L513)*
+*Defined in [src/types.ts:513](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L513)*
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 • **secret**: *string*
 
-*Defined in [src/types.ts:514](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L514)*
+*Defined in [src/types.ts:514](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L514)*

--- a/docs/interfaces/_types_.ioauthcredentials.md
+++ b/docs/interfaces/_types_.ioauthcredentials.md
@@ -20,7 +20,7 @@
 
 • **fingerprint**: *string*
 
-*Defined in [src/types.ts:501](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L501)*
+*Defined in [src/types.ts:509](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L509)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **refreshToken**: *string*
 
-*Defined in [src/types.ts:500](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L500)*
+*Defined in [src/types.ts:508](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L508)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **token**: *string*
 
-*Defined in [src/types.ts:499](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L499)*
+*Defined in [src/types.ts:507](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L507)*

--- a/docs/interfaces/_types_.ioauthcredentials.md
+++ b/docs/interfaces/_types_.ioauthcredentials.md
@@ -20,7 +20,7 @@
 
 • **fingerprint**: *string*
 
-*Defined in [src/types.ts:509](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L509)*
+*Defined in [src/types.ts:509](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L509)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **refreshToken**: *string*
 
-*Defined in [src/types.ts:508](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L508)*
+*Defined in [src/types.ts:508](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L508)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **token**: *string*
 
-*Defined in [src/types.ts:507](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L507)*
+*Defined in [src/types.ts:507](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L507)*

--- a/docs/interfaces/_types_.itrackedmod.md
+++ b/docs/interfaces/_types_.itrackedmod.md
@@ -21,7 +21,7 @@ response to a request for tracked mods
 
 • **domain_name**: *string*
 
-*Defined in [src/types.ts:438](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L438)*
+*Defined in [src/types.ts:446](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L446)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • **mod_id**: *number*
 
-*Defined in [src/types.ts:437](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L437)*
+*Defined in [src/types.ts:445](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L445)*

--- a/docs/interfaces/_types_.itrackedmod.md
+++ b/docs/interfaces/_types_.itrackedmod.md
@@ -21,7 +21,7 @@ response to a request for tracked mods
 
 • **domain_name**: *string*
 
-*Defined in [src/types.ts:446](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L446)*
+*Defined in [src/types.ts:446](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L446)*
 
 ___
 
@@ -29,4 +29,4 @@ ___
 
 • **mod_id**: *number*
 
-*Defined in [src/types.ts:445](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L445)*
+*Defined in [src/types.ts:445](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L445)*

--- a/docs/interfaces/_types_.itrackresponse.md
+++ b/docs/interfaces/_types_.itrackresponse.md
@@ -20,6 +20,6 @@
 
 • **message**: *string*
 
-*Defined in [src/types.ts:470](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L470)*
+*Defined in [src/types.ts:478](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L478)*
 
 textual result of the action, something like "User 123 is now Tracking Mod: 456"

--- a/docs/interfaces/_types_.itrackresponse.md
+++ b/docs/interfaces/_types_.itrackresponse.md
@@ -20,6 +20,6 @@
 
 • **message**: *string*
 
-*Defined in [src/types.ts:478](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L478)*
+*Defined in [src/types.ts:478](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L478)*
 
 textual result of the action, something like "User 123 is now Tracking Mod: 456"

--- a/docs/interfaces/_types_.iupdateentry.md
+++ b/docs/interfaces/_types_.iupdateentry.md
@@ -22,7 +22,7 @@ an entry in the update list
 
 • **latest_file_update**: *number*
 
-*Defined in [src/types.ts:502](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L502)*
+*Defined in [src/types.ts:502](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L502)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **latest_mod_activity**: *number*
 
-*Defined in [src/types.ts:503](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L503)*
+*Defined in [src/types.ts:503](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L503)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 • **mod_id**: *number*
 
-*Defined in [src/types.ts:501](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L501)*
+*Defined in [src/types.ts:501](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L501)*

--- a/docs/interfaces/_types_.iupdateentry.md
+++ b/docs/interfaces/_types_.iupdateentry.md
@@ -22,7 +22,7 @@ an entry in the update list
 
 • **latest_file_update**: *number*
 
-*Defined in [src/types.ts:494](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L494)*
+*Defined in [src/types.ts:502](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L502)*
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 • **latest_mod_activity**: *number*
 
-*Defined in [src/types.ts:495](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L495)*
+*Defined in [src/types.ts:503](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L503)*
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 • **mod_id**: *number*
 
-*Defined in [src/types.ts:493](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L493)*
+*Defined in [src/types.ts:501](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L501)*

--- a/docs/interfaces/_types_.iuser.md
+++ b/docs/interfaces/_types_.iuser.md
@@ -20,7 +20,7 @@
 
 • **member_group_id**: *number*
 
-*Defined in [src/types.ts:37](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L37)*
+*Defined in [src/types.ts:37](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L37)*
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 • **member_id**: *number*
 
-*Defined in [src/types.ts:36](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L36)*
+*Defined in [src/types.ts:36](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L36)*
 
 ___
 
@@ -36,4 +36,4 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:38](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L38)*
+*Defined in [src/types.ts:38](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L38)*

--- a/docs/interfaces/_types_.ivalidatekeyresponse.md
+++ b/docs/interfaces/_types_.ivalidatekeyresponse.md
@@ -26,7 +26,7 @@ result of the validateKey request
 
 • **email**: *string*
 
-*Defined in [src/types.ts:28](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L28)*
+*Defined in [src/types.ts:28](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L28)*
 
 email address of the user
 
@@ -36,7 +36,7 @@ ___
 
 • **is_premium**: *boolean*
 
-*Defined in [src/types.ts:20](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L20)*
+*Defined in [src/types.ts:20](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L20)*
 
 user is premium
 
@@ -46,7 +46,7 @@ ___
 
 • **is_supporter**: *boolean*
 
-*Defined in [src/types.ts:24](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L24)*
+*Defined in [src/types.ts:24](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L24)*
 
 user is supporter
 
@@ -56,7 +56,7 @@ ___
 
 • **key**: *string*
 
-*Defined in [src/types.ts:12](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L12)*
+*Defined in [src/types.ts:12](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L12)*
 
 the api key
 
@@ -66,7 +66,7 @@ ___
 
 • **name**: *string*
 
-*Defined in [src/types.ts:16](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L16)*
+*Defined in [src/types.ts:16](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L16)*
 
 User Name
 
@@ -76,7 +76,7 @@ ___
 
 • **profile_url**: *string*
 
-*Defined in [src/types.ts:32](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L32)*
+*Defined in [src/types.ts:32](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L32)*
 
 url of the user image
 
@@ -86,6 +86,6 @@ ___
 
 • **user_id**: *number*
 
-*Defined in [src/types.ts:8](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L8)*
+*Defined in [src/types.ts:8](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L8)*
 
 nexus user id

--- a/docs/modules/_nexus_.md
+++ b/docs/modules/_nexus_.md
@@ -38,7 +38,7 @@
 
 Ƭ **REST_METHOD**: *"DELETE" | "POST"*
 
-*Defined in [src/Nexus.ts:16](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L16)*
+*Defined in [src/Nexus.ts:16](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L16)*
 
 ## Variables
 
@@ -46,7 +46,7 @@
 
 • **format**: *any*
 
-*Defined in [src/Nexus.ts:9](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L9)*
+*Defined in [src/Nexus.ts:9](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L9)*
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 • **jwt**: *any*
 
-*Defined in [src/Nexus.ts:11](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L11)*
+*Defined in [src/Nexus.ts:11](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L11)*
 
 ___
 
@@ -62,7 +62,7 @@ ___
 
 • **request**: *RequestAPI‹Request‹›, CoreOptions, UriOptions | UrlOptions›*
 
-*Defined in [src/Nexus.ts:8](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L8)*
+*Defined in [src/Nexus.ts:8](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L8)*
 
 ___
 
@@ -70,7 +70,7 @@ ___
 
 • **setCookieParser**: *any*
 
-*Defined in [src/Nexus.ts:10](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L10)*
+*Defined in [src/Nexus.ts:10](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L10)*
 
 ## Functions
 
@@ -78,7 +78,7 @@ ___
 
 ▸ **handleRestResult**(`resolve`: any, `reject`: any, `url`: string, `error`: any, `response`: request.RequestResponse, `body`: any, `onUpdateLimit`: function): *any*
 
-*Defined in [src/Nexus.ts:35](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L35)*
+*Defined in [src/Nexus.ts:35](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L35)*
 
 **Parameters:**
 
@@ -113,7 +113,7 @@ ___
 
 ▸ **parseRequestCookies**(`args`: [IRequestArgs](../interfaces/_nexus_.irequestargs.md)): *[IRequestArgs](../interfaces/_nexus_.irequestargs.md)*
 
-*Defined in [src/Nexus.ts:155](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L155)*
+*Defined in [src/Nexus.ts:155](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L155)*
 
 **Parameters:**
 
@@ -129,7 +129,7 @@ ___
 
 ▸ **rest**(`url`: string, `args`: [IRequestArgs](../interfaces/_nexus_.irequestargs.md), `onUpdateLimit`: function, `method?`: [REST_METHOD](_nexus_.md#rest_method)): *Promise‹any›*
 
-*Defined in [src/Nexus.ts:164](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L164)*
+*Defined in [src/Nexus.ts:164](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L164)*
 
 **Parameters:**
 
@@ -158,7 +158,7 @@ ___
 
 ▸ **restGet**(`url`: string, `args`: [IRequestArgs](../interfaces/_nexus_.irequestargs.md), `onUpdateLimit`: function): *Promise‹any›*
 
-*Defined in [src/Nexus.ts:107](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L107)*
+*Defined in [src/Nexus.ts:107](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L107)*
 
 **Parameters:**
 
@@ -185,7 +185,7 @@ ___
 
 ▸ **restPost**(`method`: [REST_METHOD](_nexus_.md#rest_method), `url`: string, `args`: [IRequestArgs](../interfaces/_nexus_.irequestargs.md), `onUpdateLimit`: function): *Promise‹any›*
 
-*Defined in [src/Nexus.ts:130](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L130)*
+*Defined in [src/Nexus.ts:130](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L130)*
 
 **Parameters:**
 
@@ -214,7 +214,7 @@ ___
 
 ▸ **transformJwtToValidationResult**(`oAuthCredentials`: [IOAuthCredentials](../interfaces/_types_.ioauthcredentials.md)): *[IValidateKeyResponse](../interfaces/_types_.ivalidatekeyresponse.md)*
 
-*Defined in [src/Nexus.ts:170](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Nexus.ts#L170)*
+*Defined in [src/Nexus.ts:170](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Nexus.ts#L170)*
 
 **Parameters:**
 

--- a/docs/modules/_parameters_.md
+++ b/docs/modules/_parameters_.md
@@ -24,7 +24,7 @@
 
 • **API_URL**: *string* = "https://api.nexusmods.com/v1"
 
-*Defined in [src/parameters.ts:17](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L17)*
+*Defined in [src/parameters.ts:17](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L17)*
 
 ___
 
@@ -32,7 +32,7 @@ ___
 
 • **DEFAULT_TIMEOUT_MS**: *number* = 30000
 
-*Defined in [src/parameters.ts:11](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L11)*
+*Defined in [src/parameters.ts:11](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L11)*
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 • **DELAY_AFTER_429_MS**: *number* = 1000
 
-*Defined in [src/parameters.ts:15](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L15)*
+*Defined in [src/parameters.ts:15](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L15)*
 
 ___
 
@@ -48,7 +48,7 @@ ___
 
 • **MAX_FILE_SIZE**: *number* = 20 * 1024 * 1024
 
-*Defined in [src/parameters.ts:30](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L30)*
+*Defined in [src/parameters.ts:30](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L30)*
 
 ___
 
@@ -56,7 +56,7 @@ ___
 
 • **MAX_JWT_REFRESH_TRIES**: *number* = 3
 
-*Defined in [src/parameters.ts:32](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L32)*
+*Defined in [src/parameters.ts:32](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L32)*
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 • **PROTOCOL_VERSION**: *string* = require('../package.json').version.split('-')[0]
 
-*Defined in [src/parameters.ts:23](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L23)*
+*Defined in [src/parameters.ts:23](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L23)*
 
 ___
 
@@ -72,7 +72,7 @@ ___
 
 • **QUOTA_MAX**: *number* = 50
 
-*Defined in [src/parameters.ts:7](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L7)*
+*Defined in [src/parameters.ts:7](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L7)*
 
 ___
 
@@ -80,7 +80,7 @@ ___
 
 • **QUOTA_MAX_PREMIUM**: *number* = 50
 
-*Defined in [src/parameters.ts:9](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L9)*
+*Defined in [src/parameters.ts:9](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L9)*
 
 ___
 
@@ -88,7 +88,7 @@ ___
 
 • **QUOTA_RATE_MS**: *number* = 1000
 
-*Defined in [src/parameters.ts:5](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L5)*
+*Defined in [src/parameters.ts:5](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L5)*
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 • **SECURITY_PROTOCOL_VERSION**: *string* = "TLSv1_2_method"
 
-*Defined in [src/parameters.ts:27](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L27)*
+*Defined in [src/parameters.ts:27](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L27)*
 
 ___
 
@@ -104,4 +104,4 @@ ___
 
 • **USER_SERVICE_API_URL**: *string* = "https://users.nexusmods.com"
 
-*Defined in [src/parameters.ts:19](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/parameters.ts#L19)*
+*Defined in [src/parameters.ts:19](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/parameters.ts#L19)*

--- a/docs/modules/_quota_.md
+++ b/docs/modules/_quota_.md
@@ -18,7 +18,7 @@
 
 ▸ **delay**(`milliseconds`: number): *Promise‹void›*
 
-*Defined in [src/Quota.ts:3](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/Quota.ts#L3)*
+*Defined in [src/Quota.ts:3](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/Quota.ts#L3)*
 
 **Parameters:**
 

--- a/docs/modules/_types_.md
+++ b/docs/modules/_types_.md
@@ -44,7 +44,7 @@
 
 Ƭ **EndorsedStatus**: *"Undecided" | "Abstained" | "Endorsed"*
 
-*Defined in [src/types.ts:41](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L41)*
+*Defined in [src/types.ts:41](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L41)*
 
 ___
 
@@ -52,7 +52,7 @@ ___
 
 Ƭ **ModStatus**: *"under_moderation" | "published" | "not_published" | "publish_with_game" | "removed" | "wastebinned" | "hidden"*
 
-*Defined in [src/types.ts:46](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L46)*
+*Defined in [src/types.ts:46](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L46)*
 
 possible states the mod can be in
 
@@ -62,6 +62,6 @@ ___
 
 Ƭ **UpdatePeriod**: *"1d" | "1w" | "1m"*
 
-*Defined in [src/types.ts:495](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L495)*
+*Defined in [src/types.ts:495](https://github.com/Nexus-Mods/node-nexus-api/blob/master/src/types.ts#L495)*
 
 range of updates to query

--- a/docs/modules/_types_.md
+++ b/docs/modules/_types_.md
@@ -62,6 +62,6 @@ ___
 
 Ƭ **UpdatePeriod**: *"1d" | "1w" | "1m"*
 
-*Defined in [src/types.ts:487](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L487)*
+*Defined in [src/types.ts:495](https://github.com/Nexus-Mods/node-nexus-api/blob/af3f187/src/types.ts#L495)*
 
 range of updates to query

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
 export * from './types';
-export { NexusError, ParameterInvalid, RateLimitError, TimeoutError } from './customErrors';
+export { NexusError, ParameterInvalid, ProtocolError, RateLimitError, TimeoutError } from './customErrors';
 import Nexus from './Nexus';
 export default Nexus;

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 var customErrors_1 = require("./customErrors");
 exports.NexusError = customErrors_1.NexusError;
 exports.ParameterInvalid = customErrors_1.ParameterInvalid;
+exports.ProtocolError = customErrors_1.ProtocolError;
 exports.RateLimitError = customErrors_1.RateLimitError;
 exports.TimeoutError = customErrors_1.TimeoutError;
 const Nexus_1 = require("./Nexus");

--- a/lib/index.js.map
+++ b/lib/index.js.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;AACA,+CAA4F;AAAnF,oCAAA,UAAU,CAAA;AAAE,0CAAA,gBAAgB,CAAA;AAAE,wCAAA,cAAc,CAAA;AAAE,sCAAA,YAAY,CAAA;AACnE,mCAA4B;AAE5B,kBAAe,eAAK,CAAC"}
+{"version":3,"file":"index.js","sourceRoot":"","sources":["../src/index.ts"],"names":[],"mappings":";;AACA,+CAA2G;AAAlG,oCAAA,UAAU,CAAA;AAAE,0CAAA,gBAAgB,CAAA;AAAE,uCAAA,aAAa,CAAA;AAAE,wCAAA,cAAc,CAAA;AAAE,sCAAA,YAAY,CAAA;AAClF,mCAA4B;AAE5B,kBAAe,eAAK,CAAC"}

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -31,6 +31,8 @@ export interface IModInfo {
     status: ModStatus;
     available: boolean;
     picture_url?: string;
+    mod_downloads: number;
+    mod_unique_downloads: number;
     created_timestamp: number;
     created_time: string;
     updated_timestamp: number;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/ref-union": "^0.0.28",
     "@types/request": "^2.47.0",
     "@types/typescript": "^2.0.0",
-    "typedoc": "^0.17.0",
+    "typedoc": "^0.22.17",
     "typedoc-plugin-markdown": "^2.2.17",
     "typescript": "^3.8.3"
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,14 @@ export interface IModInfo {
    */
   picture_url?: string;
   /**
+   * downloads count
+   */
+  mod_downloads: number;
+  /**
+   * unique downloads count
+   */
+  mod_unique_downloads: number;
+  /**
    * unix timestamp of when the mod was created
    */
   created_timestamp: number;


### PR DESCRIPTION
I added `mod_downloads` and `mod_unique_downloads` because they were not in `IModInfo` for some reason.